### PR TITLE
fix: bbolt module URL

### DIFF
--- a/cmd/rpc_examples/pong_server/pong_server.go
+++ b/cmd/rpc_examples/pong_server/pong_server.go
@@ -15,7 +15,7 @@ import "fmt"
 import "time"
 import "crypto/sha1"
 
-import "etcd.io/bbolt"
+import "go.etcd.io/bbolt"
 
 import "github.com/go-logr/logr"
 import "gopkg.in/natefinch/lumberjack.v2"


### PR DESCRIPTION
Pong server example missed out on bbolt module URL update