### PR TITLE
fix miniblock spam bug

### DIFF
--- a/p2p/rpc_notifications.go
+++ b/p2p/rpc_notifications.go
@@ -16,17 +16,19 @@
 
 package p2p
 
-import "fmt"
-import "sync/atomic"
-import "encoding/binary"
-import "time"
+import (
+	"encoding/binary"
+	"fmt"
+	"sync/atomic"
+	"time"
 
-import "github.com/deroproject/derohe/block"
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/errormsg"
-import "github.com/deroproject/derohe/transaction"
-import "github.com/deroproject/derohe/metrics"
-import "github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/block"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/errormsg"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/metrics"
+	"github.com/deroproject/derohe/transaction"
+)
 
 // handles notifications of inventory
 func (c *Connection) NotifyINV(request ObjectList, response *Dummy) (err error) {
@@ -128,6 +130,12 @@ func (c *Connection) NotifyMiniBlock(request Objects, response *Dummy) (err erro
 		if err = mbl.Deserialize(request.MiniBlocks[i]); err != nil {
 			return err
 		}
+
+		// prevent nodes to spam old mini blocks
+		if chain.Get_Height() > int64(mbl.Height) {
+			return fmt.Errorf("Stale MiniBlock received")
+		}
+
 		mbls = append(mbls, mbl)
 	}
 


### PR DESCRIPTION
Any malicious node can retrieve all mini blocks from chain and send them all to all connected peers to increase bandwith use, and to consume CPU by verifying all these mini blocks.

The fix consist to reject all stale mini blocks to prevent such spam because nodes getting such old mini blocks are going to broadcast them too spamming the whole network.

Because `flip_top` function has a `return` at beginning, I don't verify that the mini block height is not greater than stable limit chain.

