### PR TITLE
Leak path

### DIFF
--- a/blockchain/storefs.go
+++ b/blockchain/storefs.go
@@ -285,13 +285,20 @@ func (s *storefs) ReadTX(h [32]byte) ([]byte, error) {
 		dir := s.getpath(h)
 		file := filepath.Join(dir, fmt.Sprintf("%x.tx", h[:]))
 		if data, err := ioutil.ReadFile(file); err == nil {
-			return data, err
+			logger.V(4).Info("cannot read tx", "tx", fmt.Sprintf("%x", h), "err", err)
+			return data, fmt.Errorf("tx %x not found", h[:])
 		}
 	}
 
 	dir := s.getpathtx(h)
 	file := filepath.Join(dir, fmt.Sprintf("%x.tx", h[:]))
-	return ioutil.ReadFile(file)
+	res, err := ioutil.ReadFile(file)
+	if err != nil {
+		logger.V(4).Info("cannot read tx", "tx", fmt.Sprintf("%x", h), "err", err)
+		return nil, fmt.Errorf("tx %x not found", h[:])
+	}
+
+	return res, nil
 }
 
 func (s *storefs) WriteTX(h [32]byte, data []byte) (err error) {

--- a/blockchain/storetopo.go
+++ b/blockchain/storetopo.go
@@ -67,16 +67,18 @@ func (s *storetopofs) Count() int64 {
 // it basically represents Load_Block_Topological_order_at_index
 // reads an entry at specific location
 func (s *storetopofs) Read(index int64) (TopoRecord, error) {
-
 	var buf [TOPORECORD_SIZE]byte
 	var record TopoRecord
 
 	if n, err := s.topomapping.ReadAt(buf[:], index*TOPORECORD_SIZE); int64(n) != TOPORECORD_SIZE {
-		return record, err
+		logger.V(4).Info("cannot read topo record", "index", index, "err", err)
+		return record, fmt.Errorf("cannot read topo record at index %d", index)
 	}
+
 	copy(record.BLOCK_ID[:], buf[:])
 	record.State_Version = binary.LittleEndian.Uint64(buf[len(record.BLOCK_ID):])
 	record.Height = int64(binary.LittleEndian.Uint64(buf[len(record.BLOCK_ID)+8:]))
+
 	return record, nil
 }
 


### PR DESCRIPTION
## Description

Disk path of a node can be easily leaked by building a specific payload to create a negative index for the filesystem.
This native error is directly returned which should not.

A verification of the right order is also included to remove the surface of attacks.
 
## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [X] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).