### PR TITLE
add `size` in `block_header` and `fees`, `size` in tx result  API

### DIFF
--- a/cmd/derod/rpc/blockheader.go
+++ b/cmd/derod/rpc/blockheader.go
@@ -17,11 +17,13 @@
 package rpc
 
 //import "fmt"
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/blockchain"
+import (
+	"github.com/deroproject/derohe/blockchain"
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/rpc"
+)
 
 // this function is only used by the RPC and is not used by the core and should be moved to RPC interface
 
@@ -49,6 +51,7 @@ func GetBlockHeader(chain *blockchain.Blockchain, hash crypto.Hash) (result rpc.
 	result.SideBlock = chain.Isblock_SideBlock(hash)
 	result.Reward = blockchain.CalcBlockReward(uint64(result.Height))
 	result.TXCount = int64(len(bl.Tx_hashes))
+	result.Size = len(bl.Serialize())
 
 	for i := range bl.Tips {
 		result.Tips = append(result.Tips, bl.Tips[i].String())

--- a/cmd/derod/rpc/rpc_dero_gettransactions.go
+++ b/cmd/derod/rpc/rpc_dero_gettransactions.go
@@ -16,21 +16,24 @@
 
 package rpc
 
-import "fmt"
-import "context"
-import "encoding/hex"
-import "encoding/binary"
-import "runtime/debug"
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/deroproject/derohe/blockchain"
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/dvm"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+)
 
 //import "github.com/romana/rlog"
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/cryptography/bn256"
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/dvm"
-import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/transaction"
-import "github.com/deroproject/derohe/blockchain"
 
 func GetTransaction(ctx context.Context, p rpc.GetTransaction_Params) (result rpc.GetTransaction_Result, err error) {
 
@@ -58,6 +61,10 @@ func GetTransaction(ctx context.Context, p rpc.GetTransaction_Params) (result rp
 						related.Block_Height = -1 // not mined
 						related.In_pool = true
 
+						// retrieve fees
+						related.Fees = tx.Fees()
+						related.Size = len(tx.Serialize())
+
 						result.Txs_as_hex = append(result.Txs_as_hex, hex.EncodeToString(tx.Serialize()))
 						result.Txs = append(result.Txs, related)
 					} else {
@@ -80,6 +87,10 @@ func GetTransaction(ctx context.Context, p rpc.GetTransaction_Params) (result rp
 					var related rpc.Tx_Related_Info
 
 					// check whether tx is orphan
+
+					// retrieve fees
+					related.Fees = tx.Fees()
+					related.Size = len(tx_bytes)
 
 					//if chain.Is_TX_Orphan(hash) {
 					//	result.Txs_as_hex = append(result.Txs_as_hex, "") // given empty data
@@ -164,6 +175,7 @@ func GetTransaction(ctx context.Context, p rpc.GetTransaction_Params) (result rp
 							}
 						}
 					}
+
 					for i := range invalid_blid {
 						related.InvalidBlock = append(related.InvalidBlock, invalid_blid[i].String())
 					}

--- a/rpc/daemon_rpc.go
+++ b/rpc/daemon_rpc.go
@@ -39,6 +39,7 @@ type BlockHeader_Print struct {
 	Reward    uint64   `json:"reward"`
 	Tips      []string `json:"tips"`
 	Timestamp uint64   `json:"timestamp"`
+	Size      int      `json:"size"` // block header size in bytes
 }
 
 type (
@@ -224,7 +225,8 @@ type (
 		Code           string     `json:"code"`          // smart contract code at start
 		BalanceNow     uint64     `json:"balancenow"`    // if tx is SC, give SC balance at current topo height
 		CodeNow        string     `json:"codenow"`       // smart contract code at current topo
-
+		Fees           uint64     `json:"fees"`          // fees paid by this tx
+		Size           int        `json:"size"`          // size of the tx in bytes
 	}
 )
 


### PR DESCRIPTION
## Description

Improve API by adding size, fees parameters in response.

## Type of change

Please select the right one.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [X] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).