### PR TITLE
fix --generate-new-wallet and support --wallet-file

### DIFF
--- a/cmd/dero-wallet-cli/main.go
+++ b/cmd/dero-wallet-cli/main.go
@@ -71,7 +71,7 @@ Usage:
   --testnet  	Run in testnet mode.
   --debug       Debug mode enabled, print log messages
   --unlocked    Keep wallet unlocked for cli commands (Does not confirm password before commands)
-  --generate-new-wallet Generate new wallet
+  --generate-new-wallet       Generate new wallet
   --restore-deterministic-wallet    Restore wallet from previously saved recovery seed
   --electrum-seed=<recovery-seed>   Seed to use while restoring wallet
   --socks-proxy=<socks_ip:port>  Use a proxy to connect to Daemon.
@@ -224,7 +224,13 @@ func main() {
 
 	// generare new random account if requested
 	if globals.Arguments["--generate-new-wallet"] != nil && globals.Arguments["--generate-new-wallet"].(bool) {
-		filename := choose_file_name(l)
+		var filename string
+		if globals.Arguments["--wallet-file"] != nil && len(globals.Arguments["--wallet-file"].(string)) > 0 {
+			filename = globals.Arguments["--wallet-file"].(string)
+		} else {
+			filename = choose_file_name(l)
+		}
+
 		// ask user a pass, if not provided on command_line
 		password := ""
 		if wallet_password == "" {


### PR DESCRIPTION
## Description

Fix the --generate-new-wallet option for CLI Wallet
Also support --wallet-file when using --generate-new-wallet to set the filename to use.

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [X] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).