### PR TITLE
Optimize TX fees & Pay DERO fees only one time

### DIFF
--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -140,7 +140,8 @@ rebuild_tx:
 		burn_value := transfers[t].Burn
 
 		// If user provide fees, we will use it, otherwise we will calculate it
-		should_do_fees := !fees_done && fees != 0
+		// Fees are only paid on DERO transfers, not on tokens transfers
+		should_do_fees := asset.SCID.IsZero() && !fees_done && fees != 0
 
 		if fees == 0 && asset.SCID.IsZero() && !fees_done {
 			fees = fees + uint64(len(transfers)+2)*uint64((float64(config.FEE_PER_KB)*float64(float32(len(publickeylist)/16)+w.GetFeeMultiplier())))

--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -138,7 +138,10 @@ rebuild_tx:
 
 		value := transfers[t].Amount
 		burn_value := transfers[t].Burn
-		should_do_fees := false
+
+		// If user provide fees, we will use it, otherwise we will calculate it
+		should_do_fees := !fees_done && fees != 0
+
 		if fees == 0 && asset.SCID.IsZero() && !fees_done {
 			fees = fees + uint64(len(transfers)+2)*uint64((float64(config.FEE_PER_KB)*float64(float32(len(publickeylist)/16)+w.GetFeeMultiplier())))
 			if data, err := scdata.MarshalBinary(); err != nil {
@@ -223,7 +226,7 @@ rebuild_tx:
 
 		// time for bullets-sigma
 		fees_currentasset := uint64(0)
-		if asset.SCID.IsZero() {
+		if asset.SCID.IsZero() && should_do_fees {
 			fees_currentasset = fees
 		}
 		statement := GenerateStatement(CLn, CRn, publickeylist, C, &D, fees_currentasset) // generate statement

--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -248,7 +248,7 @@ rebuild_tx:
 			// TODO add fixed size of statement + proof
 
 			// multiply total_bytes by DERO fees per KB with fee multiplier
-			fees = uint64(float64(total_bytes) * (float64(config.FEE_PER_KB) + float64(w.GetFeeMultiplier())))
+			fees = uint64(float64(total_bytes) * (float64(config.FEE_PER_KB) * float64(w.GetFeeMultiplier())))
 			should_do_fees = true
 			fees_done = true
 		}

--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -245,8 +245,6 @@ rebuild_tx:
 				}
 			}
 
-			// TODO add fixed size of statement + proof
-
 			// multiply total_bytes by DERO fees per KB with fee multiplier
 			fees = uint64(float64(total_bytes) * (float64(config.FEE_PER_KB) * float64(w.GetFeeMultiplier())))
 			should_do_fees = true

--- a/walletapi/wallet_transfer.go
+++ b/walletapi/wallet_transfer.go
@@ -16,33 +16,35 @@
 
 package walletapi
 
-import "fmt"
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+)
 
 //import "sort"
 //import "math/rand"
 //import cryptorand "crypto/rand"
 
 //import "encoding/binary"
-import "encoding/hex"
 
 //import "encoding/json"
 
 //import "github.com/vmihailenco/msgpack"
 
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/cryptography/crypto"
-
 //import "github.com/deroproject/derohe/crypto/ringct"
-import "github.com/deroproject/derohe/transaction"
 
 //import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/rpc"
 
 //import "github.com/deroproject/derohe/ddn"
 
 //import "github.com/deroproject/derohe/structures"
 //import "github.com/deroproject/derohe/blockchain/inputmaturity"
-import "github.com/deroproject/derohe/cryptography/bn256"
 
 /*
 func (w *Wallet_Memory) Transfer_Simplified(addr string, value uint64, data []byte, scdata rpc.Arguments) (tx *transaction.Transaction, err error) {
@@ -393,7 +395,7 @@ func (w *Wallet_Memory) TransferPayload0(transfers []rpc.Transfer, ringsize uint
 	max_bits += 6 // extra 6 bits
 
 	if !dry_run {
-		tx = w.BuildTransaction(transfers, rings_balances, rings, block_hash, height, scdata, treehash_raw, max_bits, gasstorage)
+		tx = w.BuildTransaction(transfers, rings_balances, rings, block_hash, height, scdata, treehash_raw, max_bits, gasstorage, 0)
 	}
 
 	if tx == nil {


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

When you create a TX with more than one transfer, you pay the total TX fees for each transfer which is too much.

The fix here try to determine how much total fees should be paid and set it in the first entry.

For example, transfer with ring size 4, only 0.00060 DERO to pay:
![image](https://github.com/deroproject/derohe/assets/22432874/80ad29fc-b136-432a-824e-721db9eddbe5)

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [X] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).