### PR TITLE
search TXID in all tokens history

### DIFF
--- a/rpc/wallet_rpc.go
+++ b/rpc/wallet_rpc.go
@@ -22,12 +22,14 @@
 
 package rpc
 
-import "fmt"
-import "time"
-import "strings"
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
 
-import "github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/cryptography/crypto"
+)
 
 // these structures are completely decoupled from blockchain and live only within the wallet
 // all inputs and outputs which modify balance are presented by this structure
@@ -286,7 +288,8 @@ type (
 // Get_Transfer_By_TXID
 type (
 	Get_Transfer_By_TXID_Params struct {
-		TXID string `json:"txid"`
+		SCID crypto.Hash `json:"scid"`
+		TXID string      `json:"txid"`
 	}
 	Get_Transfer_By_TXID_Result struct {
 		Entry Entry `json:"entry,omitempty"`

--- a/rpc/wallet_rpc.go
+++ b/rpc/wallet_rpc.go
@@ -292,6 +292,7 @@ type (
 		TXID string      `json:"txid"`
 	}
 	Get_Transfer_By_TXID_Result struct {
-		Entry Entry `json:"entry,omitempty"`
+		SCID  crypto.Hash `json:"scid,omitempty"`
+		Entry Entry       `json:"entry,omitempty"`
 	}
 )

--- a/walletapi/rpcserver/rpc_get_transfer_by_txid.go
+++ b/walletapi/rpcserver/rpc_get_transfer_by_txid.go
@@ -16,10 +16,13 @@
 
 package rpcserver
 
-import "fmt"
-import "context"
-import "runtime/debug"
-import "github.com/deroproject/derohe/rpc"
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/deroproject/derohe/rpc"
+)
 
 func GetTransferbyTXID(ctx context.Context, p rpc.Get_Transfer_By_TXID_Params) (result rpc.Get_Transfer_By_TXID_Result, err error) {
 	defer func() { // safety so if anything wrong happens, we return error
@@ -35,7 +38,7 @@ func GetTransferbyTXID(ctx context.Context, p rpc.Get_Transfer_By_TXID_Params) (
 	}
 
 	// if everything is okay, fire the query and convert the result to output format
-	result.Entry = w.wallet.Get_Payments_TXID(p.TXID)
+	result.Entry = w.wallet.Get_Payments_TXID(p.SCID, p.TXID)
 
 	if result.Entry.Height == 0 {
 		return result, fmt.Errorf("Transaction not found. TXID %s", p.TXID)

--- a/walletapi/rpcserver/rpc_get_transfer_by_txid.go
+++ b/walletapi/rpcserver/rpc_get_transfer_by_txid.go
@@ -38,7 +38,7 @@ func GetTransferbyTXID(ctx context.Context, p rpc.Get_Transfer_By_TXID_Params) (
 	}
 
 	// if everything is okay, fire the query and convert the result to output format
-	result.Entry = w.wallet.Get_Payments_TXID(p.SCID, p.TXID)
+	result.SCID, result.Entry = w.wallet.Get_Payments_TXID(p.SCID, p.TXID)
 
 	if result.Entry.Height == 0 {
 		return result, fmt.Errorf("Transaction not found. TXID %s", p.TXID)

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -307,13 +307,14 @@ func (w *Wallet_Memory) Get_Payments_DestinationPort(scid crypto.Hash, port uint
 }
 
 // return all payments within a tx there can be only 1 entry
+// ZERO SCID will also search in all other tokens
 // NOTE: what about multiple payments
 func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (crypto.Hash, rpc.Entry) {
 	w.Lock()
 	defer w.Unlock()
 
 	all_entries := w.account.EntriesNative[scid]
-	if all_entries == nil || len(all_entries) < 1 {
+	if (all_entries == nil || len(all_entries) < 1) && !scid.IsZero() {
 		return scid, rpc.Entry{}
 	}
 

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -308,12 +308,11 @@ func (w *Wallet_Memory) Get_Payments_DestinationPort(scid crypto.Hash, port uint
 
 // return all payments within a tx there can be only 1 entry
 // NOTE: what about multiple payments
-func (w *Wallet_Memory) Get_Payments_TXID(txid string) (entry rpc.Entry) {
+func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (entry rpc.Entry) {
 	w.Lock()
 	defer w.Unlock()
 
-	var zerohash crypto.Hash
-	all_entries := w.account.EntriesNative[zerohash]
+	all_entries := w.account.EntriesNative[scid]
 	if all_entries == nil || len(all_entries) < 1 {
 		return
 	}
@@ -321,6 +320,22 @@ func (w *Wallet_Memory) Get_Payments_TXID(txid string) (entry rpc.Entry) {
 	for _, e := range all_entries {
 		if txid == e.TXID {
 			return e
+		}
+	}
+
+	// Its zero, maybe its optional, check in all others tokens
+	if scid.IsZero() {
+		for scid, entries := range w.account.EntriesNative {
+			// we already processed it, skip it
+			if scid.IsZero() {
+				continue
+			}
+
+			for _, e := range entries {
+				if txid == e.TXID {
+					return e
+				}
+			}
 		}
 	}
 

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -308,18 +308,18 @@ func (w *Wallet_Memory) Get_Payments_DestinationPort(scid crypto.Hash, port uint
 
 // return all payments within a tx there can be only 1 entry
 // NOTE: what about multiple payments
-func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (entry rpc.Entry) {
+func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (crypto.Hash, rpc.Entry) {
 	w.Lock()
 	defer w.Unlock()
 
 	all_entries := w.account.EntriesNative[scid]
 	if all_entries == nil || len(all_entries) < 1 {
-		return
+		return scid, rpc.Entry{}
 	}
 
 	for _, e := range all_entries {
 		if txid == e.TXID {
-			return e
+			return scid, e
 		}
 	}
 
@@ -333,13 +333,13 @@ func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (entry 
 
 			for _, e := range entries {
 				if txid == e.TXID {
-					return e
+					return scid, e
 				}
 			}
 		}
 	}
 
-	return
+	return scid, rpc.Entry{}
 }
 
 // delete most of the data and prepare for rescan


### PR DESCRIPTION
## Description

RPC Method `get_transfer_by_txid` only search and work for DERO native token while we may want to query all our history including others tokens.

This PR allows to specify for which token we want to research and fallback to search in all if SCID is DERO one and no result was found.

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [X] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).