### PR TITLE
Fix: Incorrect "sender" on incoming transactions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 ## Description
 
-Please include a summary of the changes and the related issue. (Your PR should be directed to `dev` branch)
+Please include a summary of the changes and the related issue.
+
+**NOTE**: The process is the following:
+- Your pull request should be directed to `dev` branch. 
+- When it will be merged in `dev`, we will merge it to `testnet` for tests, and then into `main` for final release.
 
 Fixes # (issue)
 
@@ -19,6 +23,9 @@ Please select the right one.
   - [ ] Wallet
   - [ ] Daemon
   - [ ] Miner
+  - [ ] Explorer
+  - [ ] Simulator
+  - [ ] Misc (documentation, comments, text...)
 
 ## Checklist:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Description
+
+Please include a summary of the changes and the related issue. (Your PR should be directed to `dev` branch)
+
+Fixes # (issue)
+
+## Type of change
+
+Please select the right one.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] This will require a HardFork to be enabled
+
+## Which part is impacted ?
+
+  - [ ] Wallet
+  - [ ] Daemon
+  - [ ] Miner
+
+## Checklist:
+
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+
+## License
+
+Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,264 @@
+# Welcome to DERO
+[Twitter](https://twitter.com/DeroProject) [Discord](https://discord.gg/H95TJDp) [GitHub](https://github.com/deroproject/derohe) [Explorer](https://testnetexplorer.dero.io) [Wiki](https://wiki.dero.io) [Web Wallet](https://wallet.dero.io/)
+
+DERO is a blockchain with Smart Contracts preserving your privacy through multiple features while staying fast, secure, and accessible to all people easily.
+
+DERO is running since December 2017 and was previously running on a unique implementation of CryptoNote protocol with blockDAG and as migrated to this unique version for Smart Contracts, Services, better performance, better privacy and more security.
+
+## DERO Homomorphic Encryption
+
+### What is "Homomorphic Encryption" ?
+
+Homomorphic encryption (HE) is a form of encryption allowing one to perform calculations on encrypted data without decrypting it first. The result of the computation is in an encrypted form, when decrypted the output is the same as if the operations had been performed on the unencrypted data.
+
+It can be used for privacy-preserving outsourced storage and computation. This allows data to be encrypted and out-sourced to commercial cloud environments for processing, all while encrypted. In highly regulated industries, such as health care, and can also be used to enable new services by removing privacy barriers inhibiting data sharing. For example, predictive analytics in health care can be hard to apply via a third party service provider due to medical data privacy concerns, but if the predictive analytics service provider can operate on encrypted data instead, these privacy concerns are diminished.
+
+For more details of what is Homomorphic Encryption, please see [Wikipedia](https://en.wikipedia.org/wiki/Homomorphic_encryption).  
+
+## Summary
+
+- [Welcome to DERO](#welcome-to-dero)
+  - [DERO Homomorphic Encryption](#dero-homomorphic-encryption)
+    - [What is "Homomorphic Encryption" ?](#what-is-homomorphic-encryption-)
+  - [Summary](#summary)
+  - [About DERO Project](#about-dero-project)
+      - [Features](#features)
+  - [Transactions Sizes](#transactions-sizes)
+  - [Network Ports](#network-ports)
+    - [Mainnet](#mainnet)
+    - [Testnet](#testnet)
+  - [Technical](#technical)
+  - [DERO blockchain salient features](#dero-blockchain-salient-features)
+      - [**Erasure Coded Blocks**](#erasure-coded-blocks)
+      - [Client Protocol](#client-protocol)
+      - [Proving DERO Transactions](#proving-dero-transactions)
+  - [DERO Installation](#dero-installation)
+    - [Installation From Source](#installation-from-source)
+    - [Installation From Binary](#installation-from-binary)
+    - [Running DERO Daemon](#running-dero-daemon)
+    - [DERO CLI Wallet](#dero-cli-wallet)
+    - [DERO Explorer](#dero-explorer)
+
+## About DERO Project
+
+DERO is running since December 2017 and was previously running on a unique [implementation](https://github.com/deroproject/derosuite) of CryptoNote protocol with blockDAG and as migrated to this unique version for Smart Contracts, Services, better performance, better privacy and more security.
+
+Consensus algorithm is PoW based on [AstroBWT](https://github.com/deroproject/astrobwt), a ASIC/FPGA/GPU resistant CPU mining algorithm to improve decentralization and lower the barrier of joining the network.
+
+DERO is industry leading and the first blockchain to have Homomorphic Encryption, bulletproofs and a fully TLS encrypted network.
+
+The fully distributed ledger processes transactions with a  16s (sixty-seconds) average block time and is secure against majority hashrate attacks.
+
+DERO is the first Homomorphic Encryption based blockchain to have Smart Contracts contracts on its native chain without any extra layers or secondary blockchains.
+
+At present DERO has implemented Smart Contracts for previous mainnet implementation running on CryptoNote protocol which can be found [here](https://github.com/deroproject/documentation/blob/master/testnet/stargate.md).
+
+#### Features
+
+-  **Homomorphic account based model** 
+Check blockchain/transaction_execute.go line 82-95
+
+- **Instant account balances**
+It need only 66 bytes of data from the blockchain.
+
+- **~~DAG/MINIDAG with 1 miniblock every second~~**
+**NOTE**: This as been replaced by a mini block system. Each block has 10 mini blocks to rewards up to 10 differents miners at the same time for each block, by splitting the difficulty and the result of the final block.
+ 
+- **Mining Decentralization**
+No more mining pools needed, with a daily ~54000 mini blocks.
+Solo Mining is much more available than any others blockchains.
+
+- **Erasure coded blocks**
+Worlds first Erasure Coded Propagation protocol, which allows 100x block size without increasing propagation delays, lower bandwidth requirements and provide very low propagation time. 
+
+- **Light weight and efficient wallets**
+No more chain scanning or wallet scanning the whole chain to detect funds, no key images. By connecting to a synchronized node, you will retrieve your available funds in few seconds.
+
+- **Small disk cost for blockchain account**
+Fixed per account cost of 66 bytes in blockchain only which allow a immense scalability.
+
+- **Anonymous Transactions**
+Provide completely anonymous transactions and deniability thanks to Many-Out-Of-Many Proofs using Bulletproofs and Sigma Protocol, nobody except you and the receiver account will know the real parties of the transaction.
+ 
+- **Fixed Transaction Size**
+Only ~2.5KB for a transaction using ring size set to 8, or ~3.4 KB with ring size set to 16.
+Transactions size have a logarithm growth based on the anonymity set and must be chosen in powers of 2.
+
+- **Homomorphic Assets**
+programmable Smart Contracts with fixed overhead per asset.
+Your Smart Contract is open source but its data related to balances are completely encrypted like the native coin.
+
+- **Pruning Blockchain**
+Allows chain pruning on daemons to control growth of data on daemons and keep a low disk usage. This allows immense scability as you can reduce a blockchain of few hundred GBs to only few GBs while still being secure using merkle proofs.<br>
+_Example_: disk requirements of 1 billion accounts (assumming it does not want to keep history of transactions, but keeps proofs to prove that the node is in sync with all other nodes)<br>
+Requirement of 1 account is only 66 bytes
+Assumming storage overhead per account of 128 bytes (which is constant)
+Total requirements = (66 + 128)GB ~ 200GB
+Assuming we are off by factor of 4, its only 800GB.<br>
+Note that, Even after 1 trillion transactions, 1 billion accounts will consume 800GB only, If history is not maintained, and everything still will be in proved state using merkle roots.
+And so, Even Raspberry Pi can host the entire chain.
+
+- **Low Transaction Generation Time**
+Generating a transaction takes less than 25 ms.
+
+- **Low Transaction Verification Time**
+Transaction verification takes even less than 25ms.
+
+- **No trusted setup, no hidden parameters**
+Everything is open-source, available, to anyone to provide trustless and fully decentralized blockchain.
+ 
+- **Provability**
+Senders of a transaction can prove to receivers what amount they have send without revealing themselves.
+
+
+## Transactions Sizes
+
+| Ring Size | Transaction Size (in bytes) |
+|:---------:|:---------------------------:|
+|     2     |             1553            |
+|     4     |             2013            |
+|     8     |             2605            |
+|     16    |             3461            |
+|     32    |             4825            |
+|     64    |             7285            |
+|    128    |            11839            |
+|    512    |            ~35000           |
+
+**NOTE:** Plan to reduce TX sizes further.
+
+## Network Ports
+
+### Mainnet
+
+- **P2P Default Port**: 10101
+- **RPC Default Port**: 10102
+- **Wallet RPC Default Port**: 10103
+
+### Testnet
+
+- **P2P Default Port**: 40401
+- **RPC Default Port**: 40402
+- **Wallet RPC Default Port**: 40403
+
+## Technical
+
+For specific details of current DERO core (daemon) implementation and capabilities, see below:
+
+- ~~**DAG**: No orphan blocks, No soft-forks.~~
+**NOTE**: This feature has been disabled for mainnet to reduce load for small devices.
+
+- **BulletProofs**: Non Interactive Zero-Knowledge Range-Proofs (NIZK)
+
+- **AstroBWT**: This is memory-bound algorithm. This provides assurance that all miners are equal. ( No miner has any advantage over common miners).
+
+- **P2P Protocol**: This layers controls exchange of blocks, transactions and blockchain itself.
+
+- **Pederson Commitment**: (Part of ring confidential transactions): Pederson commitment algorithm is a cryptographic primitive that allows user to commit to a chosen value while keeping it hidden to others. Pederson commitment is used to hide all amounts without revealing the actual amount. It is a homomorphic commitment scheme.
+
+- **Homomorphic Encryption**: Homomorphic Encryption is used to to do operations such as addition/substraction to settle balances with data being always encrypted (Balances are never decrypted before/during/after operations in any form.).
+
+- **Homomorphic Ring Confidential Transactions**: Gives untraceability, privacy and fungibility while making sure that the system is stable and secure.
+
+- **Core-Consensus Protocol implemented**: Consensus protocol serves 2 major purpose:
+	- Protects the system from adversaries and protects it from forking and tampering.
+	- Next block in the chain is the one and only correct version of truth (balances).
+
+- **Proof-of-Work(PoW) algorithm**: PoW part of core consensus protocol which is used to cryptographically prove that X amount of work has been done to successfully find a block.
+
+- **Difficulty algorithm**: Difficulty algorithm controls the system so as blocks are found roughly at the same speed, irrespective of the number and amount of mining power deployed.
+
+- **Serialization/De-serialization of blocks**: Capability to encode/decode/process blocks.
+
+- **Serialization/De-serialization of transactions**: Capability to encode/decode/process transactions.
+
+- **Transaction validity and verification**: Any transactions flowing within the DERO network are validated, verified.
+
+- **Socks proxy**: Socks proxy has been implemented and integrated within the daemon to decrease user identifiability and improve user anonymity.
+
+- **Interactive daemon**: can print blocks, txs, even entire blockchain from within the daemon
+	-	`version`, `peer_list` `status`, `diff`, `print_bc`, `print_block`, `print_tx` and several other commands implemented
+
+- **Networks**: DERO Daemon has both mainnet and testnet support.
+
+- **Enhanced Reliability, Privacy, Security, Useability, Portabilty assured.**
+
+## DERO blockchain salient features
+
+- 16 Second Block time.
+- Extremely fast transactions with one minute/block confirmation time.
+- SSL/TLS P2P Network.
+- Homomorphic: Fully Encrypted Blockchain
+- Ring signatures.
+- Fully Auditable Supply.
+- DERO blockchain is written from scratch in Golang.
+- Developed and maintained by original developers.
+
+#### **Erasure Coded Blocks**
+
+Traditional Blockchains process blocks as single unit of computation(if a double-spend tx occurs within the block, entire block is rejected). As soon as a block is found, it is sent to all its peers.DERO blockchain erasure codes the block into 48 chunks, dispersing and chunks are dispersed to peers randomly.Any peer receiving any 16 chunks( from 48 chunks) can regerate the block and thus lower overheads and lower propagation time.
+
+#### Client Protocol
+
+Traditional Blockchains process blocks as single unit of computation(if a double-spend tx occurs within the block, entire block is rejected). However DERO network accepts such blocks since DERO blockchain considers transaction as a single unit of computation.DERO blocks may contain duplicate or double-spend transactions which are filtered by client protocol and ignored by the network. DERO DAG processes transactions atomically one transaction at a time.
+
+#### Proving DERO Transactions
+
+DERO blockchain is completely private, so anyone cannot view, confirm, verify any other's wallet balance or any transactions.
+
+So to prove any transaction you require *TXID* and *deroproof*.
+deroproof can be obtained using `get_tx_key` command in dero-wallet-cli.
+
+Enter the *TXID* and *deroproof* in [DERO Explorer](https://testnetexplorer.dero.io)
+![DERO Explorer Proving Transaction](https://github.com/deroproject/documentation/raw/master/images/explorer-prove-tx.png)
+
+## DERO Installation
+
+DERO is written in golang and very easy to install both from source and binary.
+  
+### Installation From Source
+
+First you need to install Golang if not already, minimum version required for Golang is 1.17.
+
+In go workspace, execute:
+`go get -u github.com/deroproject/derohe/...`
+
+When the command has finished, check go workspace bin folder for binaries.
+For example, on Linux machine the following binaries will be created:
+-  `derod-linux-amd64`: DERO Daemon
+-  `dero-wallet-cli-linux-amd64`: DERO CLI Wallet
+-  `explorer-linux-amd64`: DERO Explorer (Yes, DERO has prebuilt personal explorer also for advance privacy users)
+
+### Installation From Binary
+
+Download [DERO binaries](https://github.com/deroproject/derohe/releases)  for ARM, INTEL, MAC platform and Windows, Mac, FreeBSD, OpenBSD, Linux (or any others availables platforms) operating systems.
+
+### Running DERO Daemon
+
+Run derod.exe or derod-linux-amd64 depending on your operating system. It will start syncing.
+
+- DERO daemon core cryptography is highly optimized and fast.
+- Use dedicated machine and SSD for best results.
+- VPS with 2-4 Cores, 4GB RAM,15GB disk is recommended.
+
+![DERO Daemon](https://raw.githubusercontent.com/deroproject/documentation/master/images/derod1.png)
+
+### DERO CLI Wallet
+DERO cmdline wallet is menu based and very easy to operate.
+
+Use various options to create, recover, transfer balance etc.
+
+**NOTE:** DERO cmdline wallet by default connects DERO daemon running on local machine on port 20206.
+
+If DERO daemon is not running start DERO wallet with --remote option like following:
+
+**./dero-wallet-cli-linux-amd64 --remote**
+
+![DERO Wallet](https://raw.githubusercontent.com/deroproject/documentation/master/images/wallet-recover2.png)
+
+### DERO Explorer
+
+[DERO Explorer](https://explorer.dero.io/) is used to check and confirm transaction on DERO Network.
+
+DERO users can run their own explorer on local machine and can [browse](http://127.0.0.1:8080) on local machine port 8080.
+
+![DERO Explorer](https://github.com/deroproject/documentation/raw/master/images/dero_explorer.png)

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@
 Homomorphic encryption can be used for privacy-preserving outsourced storage and computation. This allows data to be encrypted and out-sourced to commercial cloud environments for processing, all while encrypted. In highly regulated industries, such as health care, homomorphic encryption can be used to enable new services by removing privacy barriers inhibiting data sharing. For example, predictive analytics in health care can be hard to apply via a third party service provider due to medical data privacy concerns, but if the predictive analytics service provider can operate on encrypted data instead, these privacy concerns are diminished.  
 
 **DERO is pleased to announce release of DERO Homomorphic Encryption Protocol testnet.** 
-DERO will migrate from exisiting CryptoNote Protocol to it's own DERO Homomorphic Encryption Blockchain Protocol(DHEBP).
+DERO will migrate from existing CryptoNote Protocol to its own DERO Homomorphic Encryption Blockchain Protocol(DHEBP).
 
 ### Table of Contents [DEROHE]
 
@@ -85,11 +85,11 @@ DERO will migrate from exisiting CryptoNote Protocol to it's own DERO Homomorphi
 
 19. Pruning chain/history for immense scalibility[while still secured using merkle proofs].
 
-20. Example disk  requirements of 1 billion accounts ( assumming it does not want to keep history of transactions, but keeps proofs to prove that the node is in sync with all other nodes)
+20. Example disk  requirements of 1 billion accounts ( assuming it does not want to keep history of transactions, but keeps proofs to prove that the node is in sync with all other nodes)
     
     ```
     Requirement of 1 account = 66 bytes
-    Assumming storage overhead per account of 128 bytes ( constant )
+    Assuming storage overhead per account of 128 bytes ( constant )
     Total requirements = (66 + 128)GB ~ 200GB
     Assuming we are off by factor of 4 = 800GB
     ```
@@ -122,7 +122,7 @@ DERO will migrate from exisiting CryptoNote Protocol to it's own DERO Homomorphi
 
 #### DERO Crypto
 
-&nbsp; &nbsp; &nbsp; &nbsp; Secure and fast crypto is the basic necessity of this project and adequate amount of time has been devoted to develop/study/implement/audit it. Most of the crypto such as ring signatures have been studied by various researchers and are in production by number of projects. As far as the Bulletproofs are considered, since DERO is the first one to implement/deploy, they have been given a more detailed look. First, a bare bones bulletproofs was implemented, then implementations in development were studied (Benedict Bunz,XMR, Dalek Bulletproofs) and thus improving our own implementation.  
+&nbsp; &nbsp; &nbsp; &nbsp; Secure and fast crypto is the basic necessity of this project and adequate amount of time has been devoted to develop/study/implement/audit it. Most of the crypto such as ring signatures have been studied by various researchers and are in production by number of projects. As far as the Bulletproofs are considered, since DERO is the first one to implement/deploy, they have been given a more detailed look. First, a bare bones bulletproofs was implemented, then implementations in development were studied (Benedict Bunz, XMR, Dalek Bulletproofs) and thus improving our own implementation.  
 &nbsp; &nbsp; &nbsp; &nbsp; Some new improvements were discovered and implemented (There are number of other improvements which are not explained here). Major improvements are in the Double-Base Double-Scalar Multiplication while validating bulletproofs. A typical bulletproof takes ~15-17 ms to verify. Optimised bulletproofs takes ~1 to ~2 ms(simple bulletproof, no aggregate/batching). Since, in the case of bulletproofs the bases are fixed, we can use precompute table to convert 64*2 Base Scalar multiplication into doublings and additions (NOTE: We do not use Bos-Coster/Pippienger methods). This time can be again easily decreased to .5 ms with some more optimizations. With batching and aggregation, 5000 range-proofs (~2500 TX) can be easily verified on even a laptop. The implementation for bulletproofs is in github.com/deroproject/derosuite/crypto/ringct/bulletproof.go , optimized version is in github.com/deroproject/derosuite/crypto/ringct/bulletproof_ultrafast.go
 
 &nbsp; &nbsp; &nbsp; &nbsp; There are other optimizations such as base-scalar multiplication could be done in less than a microsecond. Some of these optimizations are not yet deployed and may be deployed at a later stage.  
@@ -146,23 +146,23 @@ Wallet RPC Default Port: 40403
 1. **DAG:** No orphan blocks, No soft-forks.
 2. **BulletProofs:** Zero Knowledge range-proofs(NIZK)
 3. **AstroBWT:** This is memory-bound algorithm. This provides assurance that all miners are equal. ( No miner has any advantage over common miners).
-4. **P2P Protocol:** This layers controls exchange of blocks, transactions and blockchain itself.
+4. **P2P Protocol:** This layer controls exchange of blocks, transactions and blockchain itself.
 5. **Pederson Commitment:** (Part of ring confidential transactions): Pederson commitment algorithm is a cryptographic primitive that allows user to commit to a chosen value  while keeping it hidden to others. Pederson commitment  is used to hide all amounts without revealing the actual amount. It is a homomorphic commitment scheme.
-6. **Homomorphic Encryption:** Homomorphic Encryption is used to to do operations such as addition/substraction to settle balances with data being always encrypted (Balances are never decrypted before/during/after operations in any form.).
+6. **Homomorphic Encryption:** Homomorphic Encryption is used to do operations such as addition/substraction to settle balances with data being always encrypted (Balances are never decrypted before/during/after operations in any form.).
 7. **Homomorphic Ring Confidential Transactions:** Gives untraceability , privacy and fungibility while making sure that the system is stable and secure.
-8. **Core-Consensus Protocol implemented:** Consensus protocol serves 2 major purpose
+8. **Core-Consensus Protocol implemented:** Consensus protocol serves 2 major purposes
    1. Protects the system from adversaries and protects it from forking and tampering.
    2. Next block in the chain is the one and only correct version of truth ( balances).
 9. **Proof-of-Work(PoW) algorithm:**  PoW part of core consensus protocol which is used to cryptographically prove that X amount of work has been done to successfully find a block.
 10. **Difficulty algorithm**: Difficulty algorithm controls the system so as blocks are found roughly at the same speed, irrespective of the number and amount of mining power deployed.
 11. **Serialization/De-serialization of blocks**: Capability to encode/decode/process blocks .
 12. **Serialization/De-serialization of transactions**: Capability to encode/decode/process transactions.
-13. **Transaction validity and verification**: Any transactions flowing within the DERO network are validated,verified.
+13. **Transaction validity and verification**: Any transactions flowing within the DERO network are validated, verified.
 14. **Socks proxy:** Socks proxy has been implemented and integrated within the daemon to decrease user identifiability and improve user anonymity.
 15. **Interactive daemon** can print blocks, txs, even entire blockchain from within the daemon 
 16. **status, diff, print_bc, print_block, print_tx** and several other commands implemented
 17. GO DERO Daemon has both mainnet, testnet support.
-18. **Enhanced Reliability, Privacy, Security, Useability, Portabilty assured.**
+18. **Enhanced Reliability, Privacy, Security, Useability, Portability assured.**
 
 #### DERO blockchain salient features
 
@@ -194,7 +194,7 @@ Wallet RPC Default Port: 40403
 
 #### **Erasure Coded Blocks**
 
-        Traditional Blockchains process blocks as single unit of computation(if a double-spend tx occurs within the block, entire block is rejected). As soon as a block is found, it is sent to all its peers.DERO blockchain erasure codes the block into 48 chunks, dispersing and chunks are dispersed to peers randomly.Any peer receiving any 16 chunks( from 48 chunks) can regerate the block and thus lower overheads and lower propagation time.
+        Traditional Blockchains process blocks as single unit of computation(if a double-spend tx occurs within the block, entire block is rejected). As soon as a block is found, it is sent to all its peers.DERO blockchain erasure codes the block into 48 chunks, dispersing and chunks are dispersed to peers randomly.Any peer receiving any 16 chunks( from 48 chunks) can regenerate the block and thus lower overheads and lower propagation time.
 
 #### Client Protocol
 
@@ -208,11 +208,11 @@ Wallet RPC Default Port: 40403
 
 - DERO rocket bulletproof transactions structures are not compatible with other implementations.
 
-&nbsp; &nbsp; &nbsp; &nbsp; Also there are several optimizations planned in near future in Dero rocket bulletproofs which will lead to several times performance boost. Presently they are under study for bugs, verifications, compatibilty etc.
+&nbsp; &nbsp; &nbsp; &nbsp; Also there are several optimizations planned in near future in Dero rocket bulletproofs which will lead to several times performance boost. Presently they are under study for bugs, verifications, compatibility etc.
 
 #### 51% Attack Resistant
 
-&nbsp; &nbsp; &nbsp; &nbsp; DERO DAG implementation builds outs a main chain from the DAG network of blocks which refers to main blocks (100% reward) and side blocks (8% rewards). Side blocks contribute to chain PoW security and thus traditional 51% attacks are not possible on DERO network. If DERO network finds another block at the same height, instead of choosing one, DERO include both blocks. Thus, rendering the 51% attack futile.
+&nbsp; &nbsp; &nbsp; &nbsp; DERO DAG implementation builds outs a main chain from the DAG network of blocks which refers to main blocks (100% reward) and side blocks (8% rewards). Side blocks contribute to chain PoW security and thus traditional 51% attacks are not possible on DERO network. If DERO network finds another block at the same height, instead of choosing one, DERO includes both blocks. Thus, rendering the 51% attack futile.
 
 #### DERO Mining
 
@@ -230,7 +230,7 @@ Wallet RPC Default Port: 40403
 4. For example on Linux machine following binaries will be created:
    1. derod-linux-amd64 -> DERO daemon.  
    2. dero-wallet-cli-linux-amd64 -> DERO cmdline wallet.  
-   3. explorer-linux-amd64 -> DERO Explorer. Yes, DERO has prebuilt personal explorer also for advance privacy users.
+   3. explorer-linux-amd64 -> DERO Explorer. Yes, DERO has prebuilt personal explorer also for advanced privacy users.
 
 #### Installation From Binary
 

--- a/Start.md
+++ b/Start.md
@@ -1,30 +1,57 @@
-1] ### DEROHE Installation, https://github.com/deroproject/derohe  
+# DERO Installation
 
-        DERO is written in golang and very easy to install both from source and binary.
-Installation From Source:  
-    Install Golang, minimum Golang 1.17 required.
-    In go workspace: go get -u github.com/deroproject/derohe/...
-    Check go workspace bin folder for binaries.
-    For example on Linux machine following binaries will be created:
-        derod-linux-amd64 -> DERO daemon.
-        dero-wallet-cli-linux-amd64 -> DERO cmdline wallet.
-        explorer-linux-amd64 -> DERO Explorer. Yes, DERO has prebuilt personal explorer also for advance privacy users.
+Official source code is available here: https://github.com/deroproject/derohe
 
-Installation From Binary  
-        Download DERO binaries for ARM, INTEL, MAC platform and Windows, Mac, FreeBSD, OpenBSD, Linux etc. operating systems.  
-https://github.com/deroproject/derohe/releases
+DERO is written in golang and is very easy to install both from source and binary.
 
-2] ### Running DERO Daemon  
-./derod-linux-amd64 
+## From sources
 
-3] ### Running DERO Wallet (Use local or remote daemon) 
-./dero-wallet-cli-linux-amd64 --remote  
-https://wallet.dero.io [Web wallet]
+First you need to install Golang if not already, minimum version required for Golang is 1.17.
 
-4] ### DERO Mining Quickstart
-Run miner with wallet address and no. of threads based on your CPU.  
-./dero-miner --mining-threads 2 --daemon-rpc-address=http://testnetexplorer.dero.io:40402 --wallet-address deto1qy0ehnqjpr0wxqnknyc66du2fsxyktppkr8m8e6jvplp954klfjz2qqdzcd8p  
+In go workspace, execute:
+`go get -u github.com/deroproject/derohe/...`
 
-NOTE: Miners keep your system clock sync with NTP etc.  
-Eg on linux machine: ntpdate pool.ntp.org 
-For details visit http://wiki.dero.io
+When the command has finished, check go workspace bin folder for binaries.
+For example, on Linux machine the following binaries will be created:
+- `derod-linux-amd64`: DERO Daemon
+- `dero-wallet-cli-linux-amd64`: DERO CLI Wallet
+-  `explorer-linux-amd64`: DERO Explorer  (Yes, DERO has prebuilt personal explorer also for advance privacy users)
+
+## From Binary
+
+Download DERO binaries for ARM, INTEL, MAC platform and Windows, Mac, FreeBSD, OpenBSD, Linux (or any others availables platforms) operating systems.
+
+Official link for releases is https://github.com/deroproject/derohe/releases
+
+## Running DERO Daemon
+
+In a terminal, execute the following command:
+`./derod-linux-amd64`
+
+In case you don't want to synchronize the whole DERO Blockchain and want to synchronize really fast, add `--fastsync` option on above command. This option will downloaded a pruned (bootstrapped) chain and will works like any traditional node without using too much disk space.
+
+You can  also use `--help` option to see all available options.
+  
+## Running DERO Wallet
+
+DERO has a CLI (Command Line Interface) secure and really easy to use !
+
+If you don't want to setup and synchronize a node, execute following command:
+`./dero-wallet-cli-linux-amd64 --remote`
+
+If you have a local daemon running, delete `--remote` option.
+
+Official web wallet is at https://wallet.dero.io but its support has been dropped and we strongly recommend to use CLI wallet. 
+
+### DERO Mining Quickstart
+
+Run miner with wallet address and no. of threads based on your CPU.
+
+./dero-miner --mining-threads 2 --daemon-rpc-address=http://testnetexplorer.dero.io:40402 --wallet-address deto1qy0ehnqjpr0wxqnknyc66du2fsxyktppkr8m8e6jvplp954klfjz2qqdzcd8p
+
+NOTE: Machine where the daemon is running should keep its system clock sync with NTP for better results in performance.
+
+On a linux machine, run the following command to sync your system clock:
+`ntpdate pool.ntp.org`
+
+For more details, please visit http://wiki.dero.io

--- a/blockchain/storefs.go
+++ b/blockchain/storefs.go
@@ -285,13 +285,20 @@ func (s *storefs) ReadTX(h [32]byte) ([]byte, error) {
 		dir := s.getpath(h)
 		file := filepath.Join(dir, fmt.Sprintf("%x.tx", h[:]))
 		if data, err := ioutil.ReadFile(file); err == nil {
-			return data, err
+			logger.V(4).Info("cannot read tx", "tx", fmt.Sprintf("%x", h), "err", err)
+			return data, fmt.Errorf("tx %x not found", h[:])
 		}
 	}
 
 	dir := s.getpathtx(h)
 	file := filepath.Join(dir, fmt.Sprintf("%x.tx", h[:]))
-	return ioutil.ReadFile(file)
+	res, err := ioutil.ReadFile(file)
+	if err != nil {
+		logger.V(4).Info("cannot read tx", "tx", fmt.Sprintf("%x", h), "err", err)
+		return nil, fmt.Errorf("tx %x not found", h[:])
+	}
+
+	return res, nil
 }
 
 func (s *storefs) WriteTX(h [32]byte, data []byte) (err error) {

--- a/blockchain/storetopo.go
+++ b/blockchain/storetopo.go
@@ -67,16 +67,18 @@ func (s *storetopofs) Count() int64 {
 // it basically represents Load_Block_Topological_order_at_index
 // reads an entry at specific location
 func (s *storetopofs) Read(index int64) (TopoRecord, error) {
-
 	var buf [TOPORECORD_SIZE]byte
 	var record TopoRecord
 
 	if n, err := s.topomapping.ReadAt(buf[:], index*TOPORECORD_SIZE); int64(n) != TOPORECORD_SIZE {
-		return record, err
+		logger.V(4).Info("cannot read topo record", "index", index, "err", err)
+		return record, fmt.Errorf("cannot read topo record at index %d", index)
 	}
+
 	copy(record.BLOCK_ID[:], buf[:])
 	record.State_Version = binary.LittleEndian.Uint64(buf[len(record.BLOCK_ID):])
 	record.Height = int64(binary.LittleEndian.Uint64(buf[len(record.BLOCK_ID)+8:]))
+
 	return record, nil
 }
 

--- a/cmd/dero-wallet-cli/main.go
+++ b/cmd/dero-wallet-cli/main.go
@@ -71,7 +71,7 @@ Usage:
   --testnet  	Run in testnet mode.
   --debug       Debug mode enabled, print log messages
   --unlocked    Keep wallet unlocked for cli commands (Does not confirm password before commands)
-  --generate-new-wallet Generate new wallet
+  --generate-new-wallet       Generate new wallet
   --restore-deterministic-wallet    Restore wallet from previously saved recovery seed
   --electrum-seed=<recovery-seed>   Seed to use while restoring wallet
   --socks-proxy=<socks_ip:port>  Use a proxy to connect to Daemon.
@@ -224,7 +224,13 @@ func main() {
 
 	// generare new random account if requested
 	if globals.Arguments["--generate-new-wallet"] != nil && globals.Arguments["--generate-new-wallet"].(bool) {
-		filename := choose_file_name(l)
+		var filename string
+		if globals.Arguments["--wallet-file"] != nil && len(globals.Arguments["--wallet-file"].(string)) > 0 {
+			filename = globals.Arguments["--wallet-file"].(string)
+		} else {
+			filename = choose_file_name(l)
+		}
+
 		// ask user a pass, if not provided on command_line
 		password := ""
 		if wallet_password == "" {

--- a/cmd/dero-wallet-cli/prompt.go
+++ b/cmd/dero-wallet-cli/prompt.go
@@ -16,27 +16,27 @@
 
 package main
 
-import "os"
-import "io"
-import "fmt"
-import "bytes"
-import "time"
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/chzyer/readline"
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/walletapi"
+)
 
 //import "io/ioutil"
 //import "path/filepath"
-import "strings"
-import "unicode"
-import "strconv"
-import "encoding/hex"
-
-import "github.com/chzyer/readline"
-
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/walletapi"
-
-import "github.com/deroproject/derohe/cryptography/crypto"
 
 var account walletapi.Account
 
@@ -116,6 +116,24 @@ func handle_prompt_command(l *readline.Instance, line string) {
 		case 2: // scid balance at topoheight
 			logger.Error(err, "not implemented")
 			break
+		}
+
+	case "token_add":
+		line_parts := line_parts[1:] // remove first part
+
+		switch len(line_parts) {
+		case 0:
+			break
+		case 1:
+			scid := crypto.HashHexToHash(line_parts[0])
+			if err := wallet.TokenAdd(scid); err != nil {
+				logger.Error(err, "Token")
+			} else {
+				wallet.Save_Wallet()
+				fmt.Fprintf(l.Stderr(), "SCID "+color_green+"%s"+color_white+" added\n\n", scid.String())
+			}
+		default:
+			logger.Error(err, "not implemented")
 		}
 
 	case "rescan_bc", "rescan_spent": // rescan from 0
@@ -902,6 +920,7 @@ var completer = readline.NewPrefixCompleter(
 	readline.PcItem("help"),
 	readline.PcItem("address"),
 	readline.PcItem("balance"),
+	readline.PcItem("token_add"),
 	readline.PcItem("integrated_address"),
 	readline.PcItem("get_tx_key"),
 	readline.PcItem("filesign"),
@@ -936,6 +955,7 @@ func usage(w io.Writer) {
 	io.WriteString(w, "\t\033[1mhelp\033[0m\t\tthis help\n")
 	io.WriteString(w, "\t\033[1maddress\033[0m\t\tDisplay user address\n")
 	io.WriteString(w, "\t\033[1mbalance\033[0m\t\tDisplay user balance\n")
+	io.WriteString(w, "\t\033[1mtoken_add\033[0m\t\tAdd token\n")
 	io.WriteString(w, "\t\033[1mintegrated_address\033[0m\tDisplay random integrated address (with encrypted payment ID)\n")
 	io.WriteString(w, "\t\033[1mmenu\033[0m\t\tEnable menu mode\n")
 	io.WriteString(w, "\t\033[1mrescan_bc\033[0m\tRescan blockchain to re-obtain transaction history \n")

--- a/config/version.go
+++ b/config/version.go
@@ -20,4 +20,4 @@ import "github.com/blang/semver/v4"
 
 // right now it has to be manually changed
 // do we need to include git commitsha??
-var Version = semver.MustParse("3.5.3-117.DEROHE.STARGATE+18032023")
+var Version = semver.MustParse("3.5.3-140.DEROHE.STARGATE+13062023")

--- a/cryptography/crypto/protocol_structures.go
+++ b/cryptography/crypto/protocol_structures.go
@@ -16,11 +16,15 @@
 
 package crypto
 
-import "bytes"
-import "encoding/binary"
-import "math/big"
-import "github.com/deroproject/derohe/cryptography/bn256"
-import "github.com/deroproject/graviton"
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/graviton"
+)
 
 type Statement struct {
 	RingSize                 uint64
@@ -98,6 +102,9 @@ func (s *Statement) Deserialize(r *bytes.Reader) error {
 		return err
 	}
 	s.RingSize = 1 << length
+	if s.RingSize > 128 {
+		return fmt.Errorf("ring size is too large")
+	}
 
 	s.Bytes_per_publickey, err = r.ReadByte()
 	if err != nil {
@@ -223,3 +230,4 @@ type Proof struct {
 	//ip *InnerProduct
 }
 */
+

--- a/p2p/chain_sync.go
+++ b/p2p/chain_sync.go
@@ -388,6 +388,12 @@ func (connection *Connection) process_object_response(response Objects, sent int
 
 			return nil
 		}
+		
+		// too old TXs will be ignored for mining, but we should check incoming TX here to avoid high system load
+		if uint64(chain.Get_Height()) > tx.Height+blockchain.TX_VALIDITY_HEIGHT {
+			connection.logger.V(2).Error(err, "Incoming TX is too far in the past", "txid", tx.GetHash().String())
+			continue
+		}
 
 		if !chain.Mempool.Mempool_TX_Exist(tx.GetHash()) { // we still donot have it, so try to process it
 			if chain.Add_TX_To_Pool(&tx) == nil { // currently we are ignoring error

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1,12 +1,14 @@
 package rpc
 
-import "fmt"
-import "time"
-import "sort"
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
 
-import "github.com/fxamacker/cbor/v2"
-import "github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/fxamacker/cbor/v2"
+)
 
 // this package defines interfaces and necessary glue code Digital Network, it exposes and provides encrypted RPC calls over DERO chain
 
@@ -360,10 +362,11 @@ func (args *Arguments) Sort() {
 
 const RPC_DESTINATION_PORT = "D"  // mandatory,uint64,  used for ID of type uint64
 const RPC_SOURCE_PORT = "S"       // mandatory,uint64, used for ID
-const RPC_VALUE_TRANSFER = "V"    //uint64, this is representation and is only readable, value is never transferred
-const RPC_COMMENT = "C"           //optional,string, used for display MSG to user
-const RPC_EXPIRY = "E"            //optional,time used for Expiry for this service call
-const RPC_REPLYBACK_ADDRESS = "R" //this is mandatory this is an address,otherwise how will otherside respond
+const RPC_VALUE_TRANSFER = "V"    // uint64, this is representation and is only readable, value is never transferred
+const RPC_COMMENT = "C"           // optional,string, used for display MSG to user
+const RPC_EXPIRY = "E"            // optional,time used for Expiry for this service call
+const RPC_REPLYBACK_ADDRESS = "R" // this is mandatory this is an address,otherwise how will otherside respond
+const RPC_ASSET = "A"             // this is optional, a SCID to inform which asset we want to receive, by default DERO
 //RPC will include own address so as the other enc can respond
 
 const RPC_NEEDS_REPLYBACK_ADDRESS = "N" //optional, uint64

--- a/rpc/wallet_rpc.go
+++ b/rpc/wallet_rpc.go
@@ -22,12 +22,14 @@
 
 package rpc
 
-import "fmt"
-import "time"
-import "strings"
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
 
-import "github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/cryptography/crypto"
+)
 
 // these structures are completely decoupled from blockchain and live only within the wallet
 // all inputs and outputs which modify balance are presented by this structure
@@ -286,9 +288,11 @@ type (
 // Get_Transfer_By_TXID
 type (
 	Get_Transfer_By_TXID_Params struct {
-		TXID string `json:"txid"`
+		SCID crypto.Hash `json:"scid"`
+		TXID string      `json:"txid"`
 	}
 	Get_Transfer_By_TXID_Result struct {
-		Entry Entry `json:"entry,omitempty"`
+		SCID  crypto.Hash `json:"scid,omitempty"`
+		Entry Entry       `json:"entry,omitempty"`
 	}
 )

--- a/walletapi/daemon_communication.go
+++ b/walletapi/daemon_communication.go
@@ -997,16 +997,13 @@ func (w *Wallet_Memory) synchistory_block(scid crypto.Hash, topo int64) (err err
 								//fmt.Printf("decoding encrypted payload %x\n",tx.Payloads[t].RPCPayload)
 								crypto.EncryptDecryptUserData(crypto.Keccak256(shared_key[:], w.GetAddress().PublicKey.EncodeCompressed()), tx.Payloads[t].RPCPayload)
 								//fmt.Printf("decoded plaintext payload %x\n",tx.Payloads[t].RPCPayload)
-								sender_idx := uint(tx.Payloads[t].RPCPayload[0])
+								
 								// if ring size is 2, the other party is the sender so mark it so
 								if uint(tx.Payloads[t].Statement.RingSize) == 2 {
 									sender_idx = 0
 									if j == 0 {
 										sender_idx = 1
 									}
-								}
-
-								if sender_idx <= uint(tx.Payloads[t].Statement.RingSize) {
 									addr := rpc.NewAddressFromKeys((*crypto.Point)(tx.Payloads[t].Statement.Publickeylist[sender_idx]))
 									addr.Mainnet = w.GetNetwork()
 									entry.Sender = addr.String()

--- a/walletapi/rpcserver/rpc_get_transfer_by_txid.go
+++ b/walletapi/rpcserver/rpc_get_transfer_by_txid.go
@@ -16,10 +16,13 @@
 
 package rpcserver
 
-import "fmt"
-import "context"
-import "runtime/debug"
-import "github.com/deroproject/derohe/rpc"
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/deroproject/derohe/rpc"
+)
 
 func GetTransferbyTXID(ctx context.Context, p rpc.Get_Transfer_By_TXID_Params) (result rpc.Get_Transfer_By_TXID_Result, err error) {
 	defer func() { // safety so if anything wrong happens, we return error
@@ -35,7 +38,7 @@ func GetTransferbyTXID(ctx context.Context, p rpc.Get_Transfer_By_TXID_Params) (
 	}
 
 	// if everything is okay, fire the query and convert the result to output format
-	result.Entry = w.wallet.Get_Payments_TXID(p.TXID)
+	result.SCID, result.Entry = w.wallet.Get_Payments_TXID(p.SCID, p.TXID)
 
 	if result.Entry.Height == 0 {
 		return result, fmt.Errorf("Transaction not found. TXID %s", p.TXID)

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -307,24 +307,40 @@ func (w *Wallet_Memory) Get_Payments_DestinationPort(scid crypto.Hash, port uint
 }
 
 // return all payments within a tx there can be only 1 entry
+// ZERO SCID will also search in all other tokens
 // NOTE: what about multiple payments
-func (w *Wallet_Memory) Get_Payments_TXID(txid string) (entry rpc.Entry) {
+func (w *Wallet_Memory) Get_Payments_TXID(scid crypto.Hash, txid string) (crypto.Hash, rpc.Entry) {
 	w.Lock()
 	defer w.Unlock()
 
-	var zerohash crypto.Hash
-	all_entries := w.account.EntriesNative[zerohash]
-	if all_entries == nil || len(all_entries) < 1 {
-		return
+	all_entries := w.account.EntriesNative[scid]
+	if (all_entries == nil || len(all_entries) < 1) && !scid.IsZero() {
+		return scid, rpc.Entry{}
 	}
 
 	for _, e := range all_entries {
 		if txid == e.TXID {
-			return e
+			return scid, e
 		}
 	}
 
-	return
+	// Its zero, maybe its optional, check in all others tokens
+	if scid.IsZero() {
+		for scid, entries := range w.account.EntriesNative {
+			// we already processed it, skip it
+			if scid.IsZero() {
+				continue
+			}
+
+			for _, e := range entries {
+				if txid == e.TXID {
+					return scid, e
+				}
+			}
+		}
+	}
+
+	return scid, rpc.Entry{}
 }
 
 // delete most of the data and prepare for rescan

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -353,6 +353,11 @@ func (w *Wallet_Memory) Clean() {
 	for k := range w.account.EntriesNative {
 		delete(w.account.EntriesNative, k)
 	}
+
+	for k := range w.account.Balance {
+		delete(w.account.Balance, k)
+	}
+
 	w.account.RingMembers = map[string]int64{}
 	w.account.Balance_Result = w.account.Balance_Result[:0]
 	w.account.Registered = false

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -128,6 +128,19 @@ func (w *Wallet_Memory) InsertReplace(scid crypto.Hash, e rpc.Entry) {
 	w.account.EntriesNative[scid] = entries
 }
 
+func (w *Wallet_Memory) TokenAdd(scid crypto.Hash) (err error) {
+	w.Lock()
+	defer w.Unlock()
+
+	if _, ok := w.account.EntriesNative[scid]; !ok {
+		w.account.EntriesNative[scid] = []rpc.Entry{}
+	} else {
+		return fmt.Errorf("token already added")
+	}
+
+	return nil
+}
+
 // generate keys from using random numbers
 func Generate_Keys_From_Random() (user *Account, err error) {
 	user = &Account{Ringsize: 16, FeesMultiplier: 2.0}

--- a/walletapi/wallet.go
+++ b/walletapi/wallet.go
@@ -16,26 +16,25 @@
 
 package walletapi
 
-import "os"
-import "fmt"
-import "sort"
-import "sync"
-import "time"
-import "strings"
-import "math/big"
-import "crypto/rand"
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
-import "encoding/pem"
-import "encoding/binary"
-
-import "github.com/go-logr/logr"
-
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/cryptography/bn256"
-
-import "github.com/deroproject/derohe/walletapi/mnemonics"
-import "github.com/deroproject/derohe/transaction"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+	"github.com/deroproject/derohe/walletapi/mnemonics"
+	"github.com/go-logr/logr"
+)
 
 //import "github.com/deroproject/derohe/blockchain/inputmaturity"
 
@@ -544,14 +543,18 @@ func (w *Wallet_Memory) sign() (c, s *big.Int) {
 	return
 }
 
-// retrieve  secret key for any tx we may have created
+// retrieve secret key for any tx we may have created
 func (w *Wallet_Memory) GetTXKey(txhash string) string {
+	w.Lock()
+	defer w.Unlock()
 
-	/*for _, e := range w.account.Entries {
-		if !e.Coinbase && !e.Incoming && e.TXID == txhash {
-			return e.Proof
+	for _, entries := range w.account.EntriesNative {
+		for _, e := range entries {
+			if e.TXID == txhash {
+				return e.Proof
+			}
 		}
-	}*/
+	}
 
 	return ""
 }

--- a/walletapi/wallet_transfer.go
+++ b/walletapi/wallet_transfer.go
@@ -16,33 +16,35 @@
 
 package walletapi
 
-import "fmt"
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+)
 
 //import "sort"
 //import "math/rand"
 //import cryptorand "crypto/rand"
 
 //import "encoding/binary"
-import "encoding/hex"
 
 //import "encoding/json"
 
 //import "github.com/vmihailenco/msgpack"
 
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/cryptography/crypto"
-
 //import "github.com/deroproject/derohe/crypto/ringct"
-import "github.com/deroproject/derohe/transaction"
 
 //import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/rpc"
 
 //import "github.com/deroproject/derohe/ddn"
 
 //import "github.com/deroproject/derohe/structures"
 //import "github.com/deroproject/derohe/blockchain/inputmaturity"
-import "github.com/deroproject/derohe/cryptography/bn256"
 
 /*
 func (w *Wallet_Memory) Transfer_Simplified(addr string, value uint64, data []byte, scdata rpc.Arguments) (tx *transaction.Transaction, err error) {
@@ -54,11 +56,33 @@ func (w *Wallet_Memory) Transfer_Simplified(addr string, value uint64, data []by
 }
 */
 
+// This function set the address asset requested naively
+// This can be a security flaw for exchanges or other services who accept integrated address without necessary checks
+func (w *Wallet_Memory) TransferAssetFromAddress(transfers []rpc.Transfer, ringsize uint64, transfer_all bool, scdata rpc.Arguments, gasstorage uint64, dry_run bool) (tx *transaction.Transaction, err error) {
+	// Update all asset used in transfer to use the one from integrated address if present
+	for i := range transfers {
+		transfer := transfers[i]
+		// parse address
+		var addr *rpc.Address
+		if addr, err = rpc.NewAddress(transfer.Destination); err != nil {
+			return nil, err
+
+		}
+
+		// if address contains RPC Asset, set it as SCID
+		if addr.Arguments.Has(rpc.RPC_ASSET, rpc.DataHash) {
+			scid := addr.Arguments.Value(rpc.RPC_ASSET, rpc.DataHash).(crypto.Hash)
+			transfer.SCID = scid
+		}
+	}
+
+	return w.TransferPayload0(transfers, ringsize, transfer_all, scdata, gasstorage, dry_run)
+}
+
 // we should reply to an entry
 
 // send amount to specific addresses
 func (w *Wallet_Memory) TransferPayload0(transfers []rpc.Transfer, ringsize uint64, transfer_all bool, scdata rpc.Arguments, gasstorage uint64, dry_run bool) (tx *transaction.Transaction, err error) {
-
 	//    var  transfer_details structures.Outgoing_Transfer_Details
 	w.transfer_mutex.Lock()
 	defer w.transfer_mutex.Unlock()
@@ -238,7 +262,6 @@ func (w *Wallet_Memory) TransferPayload0(transfers []rpc.Transfer, ringsize uint
 
 	_, _, block_hash, self_e, _ = w.GetEncryptedBalanceAtTopoHeight(transfers[0].SCID, topoheight, w.GetAddress().String())
 	if err != nil {
-		fmt.Printf("self unregistered err %s\n", err)
 		return
 	}
 
@@ -300,12 +323,11 @@ func (w *Wallet_Memory) TransferPayload0(transfers []rpc.Transfer, ringsize uint
 					transfers[t].Payload_RPC = append(transfers[t].Payload_RPC, rpc.Argument{Name: rpc.RPC_DESTINATION_PORT, DataType: rpc.DataUint64, Value: addr.Arguments.Value(rpc.RPC_DESTINATION_PORT, rpc.DataUint64).(uint64)})
 					continue
 				} else {
-					fmt.Printf("integrtated address, but don't know how to process\n")
+					// Shouldn't we jus replicate them in payload_rpc ?
 					err = fmt.Errorf("integrated address used, but don't know how to process %+v", addr.Arguments)
+					return
 				}
 			}
-
-			return
 		}
 
 		var dest_e *crypto.ElGamal


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

**NOTE**: The process is the following:
- Your pull request should be directed to `dev` branch. 
- When it will be merged in `dev`, we will merge it to `testnet` for tests, and then into `main` for final release.

Fixes # (issue)

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [x] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

I'm am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).

## Summary

Wallet entries list one's wallet address for incoming transactions if the ringsize is greater than 2.
The sender index is determined by `sender_idx := uint(tx.Payloads[t].RPCPayload[0])` and isn't touched again for ringsizes > 2.
`RPCPayload[0]` always contains the receiver index. The values is placed there during transaction creation.
_GetTransferbyTXID_, _GetTransfers_ and the _exported wallet history_ are affected.
I recommend leaving the "**sender**" field blank for such transactions to avoid confusion, as the sender cannot be determined.