### PR TITLE
Fix: Incorrect sender for incoming transactions

### DIFF
--- a/walletapi/daemon_communication.go
+++ b/walletapi/daemon_communication.go
@@ -997,16 +997,13 @@ func (w *Wallet_Memory) synchistory_block(scid crypto.Hash, topo int64) (err err
 								//fmt.Printf("decoding encrypted payload %x\n",tx.Payloads[t].RPCPayload)
 								crypto.EncryptDecryptUserData(crypto.Keccak256(shared_key[:], w.GetAddress().PublicKey.EncodeCompressed()), tx.Payloads[t].RPCPayload)
 								//fmt.Printf("decoded plaintext payload %x\n",tx.Payloads[t].RPCPayload)
-								sender_idx := uint(tx.Payloads[t].RPCPayload[0])
+								
 								// if ring size is 2, the other party is the sender so mark it so
 								if uint(tx.Payloads[t].Statement.RingSize) == 2 {
 									sender_idx = 0
 									if j == 0 {
 										sender_idx = 1
 									}
-								}
-
-								if sender_idx <= uint(tx.Payloads[t].Statement.RingSize) {
 									addr := rpc.NewAddressFromKeys((*crypto.Point)(tx.Payloads[t].Statement.Publickeylist[sender_idx]))
 									addr.Mainnet = w.GetNetwork()
 									entry.Sender = addr.String()

--- a/walletapi/daemon_communication.go
+++ b/walletapi/daemon_communication.go
@@ -1000,7 +1000,7 @@ func (w *Wallet_Memory) synchistory_block(scid crypto.Hash, topo int64) (err err
 								
 								// if ring size is 2, the other party is the sender so mark it so
 								if uint(tx.Payloads[t].Statement.RingSize) == 2 {
-									sender_idx = 0
+									sender_idx := 0
 									if j == 0 {
 										sender_idx = 1
 									}


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

**NOTE**: The process is the following:
- Your pull request should be directed to `dev` branch. 
- When it will be merged in `dev`, we will merge it to `testnet` for tests, and then into `main` for final release.

Fixes # (issue)

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [x] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

I'm am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).

## Summary

Wallet entries list one's wallet address for incoming transactions if the ringsize is greater than 2.
The sender index is determined by `sender_idx := uint(tx.Payloads[t].RPCPayload[0])` and isn't touched again for ringsizes > 2.
`RPCPayload[0]` always contains the receiver index. The value is placed there during transaction creation.
_GetTransferbyTXID_, _GetTransfers_ and the _exported wallet history_ are affected.
I recommend leaving the "**sender**" field blank for such transactions to avoid confusion, as the sender cannot be determined.