### PR TITLE
fix rpc payload sender real position

### DIFF
--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -1,17 +1,20 @@
 package walletapi
 
-import "fmt"
-import "strconv"
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+	"strconv"
 
-//import "encoding/binary"
-import mathrand "math/rand"
-import "github.com/deroproject/derohe/globals"
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/config"
-import "github.com/deroproject/derohe/transaction"
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/cryptography/bn256"
+	//import "encoding/binary"
+	mathrand "math/rand"
+
+	"github.com/deroproject/derohe/config"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+)
 
 // this is run some tests and benchmarks
 type GenerateProofFunc func(scid crypto.Hash, scid_index int, s *crypto.Statement, witness *crypto.Witness, u *bn256.G1, txid crypto.Hash, burn_value uint64) *crypto.Proof
@@ -175,7 +178,9 @@ rebuild_tx:
 
 				shared_key := crypto.GenerateSharedSecret(r, publickeylist[i])
 
-				asset.RPCPayload = append([]byte{byte(uint(witness_index[1]))}, data...)
+				// witness_index[0] is sender, witness_index[1] is receiver
+				asset.RPCPayload = append([]byte{byte(uint(witness_index[0]))}, data...)
+
 				//fmt.Printf("buulding shared_key %x  index of receiver %d\n",shared_key,i)
 				//fmt.Printf("building plaintext payload %x\n",asset.RPCPayload)
 


### PR DESCRIPTION
## Description

When you check from which address the TX come from, you are always the sender. It's because during the transaction build part, we set in RPC Payload the wrong index. We set it of the receiver instead of the sender one.

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [X] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).