### PR TITLE
Fix broken fastsync

### DIFF
--- a/p2p/rpc_changeset.go
+++ b/p2p/rpc_changeset.go
@@ -36,7 +36,7 @@ func (c *Connection) ChangeSet(request ChangeList, response *Changes) (err error
 
 	c.update(&request.Common) // update common information
 
-	previous_topo := request.TopoHeights[0] // used to verify the topo heights are in order
+	previous_topo := request.TopoHeights[0] - 1 // used to verify the topo heights are in order
 	// first requested topo can't be higher than chain AND can't be lower than 10 (because of connection.TopoHeight-50-max_request_topoheights < 10)
 	if previous_topo > chain.Load_TOPO_HEIGHT() || previous_topo < 10 {
 		c.logger.V(1).Info("malformed object request received, banning peer", "request", request)


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

**NOTE**: The process is the following:
- Your pull request should be directed to `dev` branch. 
- When it will be merged in `dev`, we will merge it to `testnet` for tests, and then into `main` for final release.

Fixes # (issue)

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [x] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

I'm am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).

## Summary
The latest change made fastsync unusable.
There is a condition that always fail:
```
previous_topo := request.TopoHeights[0]
...
for _, topo := range request.TopoHeights {
		if topo <= previous_topo ...
```
In the first loop run `topo` is equal `previous_topo` and fastsync fails.

Thanks to @Slixe after a short conversation ;)