### PR TITLE
Walletapi Connect Logic Updates For More Prefixes And Parameter Inputs

### DIFF
--- a/walletapi/daemon_connectivity.go
+++ b/walletapi/daemon_connectivity.go
@@ -54,6 +54,8 @@ var rpc_client = &Client{}
 func Connect(endpoint string) (err error) {
 
 	var daemon_uri string
+
+	// Take globals arg configured daemon if endpoint param is not defined
 	if endpoint == "" {
 		Daemon_Endpoint_Active = get_daemon_address()
 	} else {
@@ -62,6 +64,7 @@ func Connect(endpoint string) (err error) {
 
 	logger.V(1).Info("Daemon endpoint ", "address", Daemon_Endpoint_Active)
 
+	// Trim off http, https, wss, ws to get endpoint to use for connecting
 	if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
 		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "https://")
 		daemon_uri = "wss://" + ld + "/ws"

--- a/walletapi/daemon_connectivity.go
+++ b/walletapi/daemon_connectivity.go
@@ -54,24 +54,37 @@ var rpc_client = &Client{}
 func Connect(endpoint string) (err error) {
 
 	var daemon_uri string
-	Daemon_Endpoint_Active = get_daemon_address()
+	if endpoint == "" {
+		Daemon_Endpoint_Active = get_daemon_address()
+	} else {
+		Daemon_Endpoint_Active = endpoint
+	}
 
 	logger.V(1).Info("Daemon endpoint ", "address", Daemon_Endpoint_Active)
 
-	if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
+	if strings.HasPrefix(Daemon_Endpoint_Active, "http") {
+		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "http://")
+		daemon_uri = "ws://" + ld + "/ws"
+
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
 		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "https://")
 		daemon_uri = "wss://" + ld + "/ws"
-		logger.V(1).Info("will use endpoint", "endpoint", daemon_uri)
 
 		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
 	} else if strings.HasPrefix(Daemon_Endpoint_Active, "wss") {
 		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "wss://")
 		daemon_uri = "wss://" + ld + "/ws"
-		logger.V(1).Info("will use endpoint", "endpoint", daemon_uri)
+
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(Daemon_Endpoint_Active, "ws") {
+		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "ws://")
+		daemon_uri = "ws://" + ld + "/ws"
 
 		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
 	} else {
 		daemon_uri = "ws://" + Daemon_Endpoint_Active + "/ws"
+
 		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
 	}
 

--- a/walletapi/daemon_connectivity.go
+++ b/walletapi/daemon_connectivity.go
@@ -30,17 +30,16 @@ package walletapi
 //import "fmt"
 
 //import "net/url"
-import "net/http"
+import (
+	"strings"
 
-import "github.com/deroproject/derohe/glue/rwc"
-
-import "github.com/creachadair/jrpc2"
-import "github.com/creachadair/jrpc2/channel"
-import "github.com/gorilla/websocket"
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+	"github.com/deroproject/derohe/glue/rwc"
+	"github.com/gorilla/websocket"
+)
 
 // there should be no global variables, so multiple wallets can run at the same time with different assset
-
-var netClient *http.Client
 
 type Client struct {
 	WS  *websocket.Conn
@@ -54,23 +53,39 @@ var rpc_client = &Client{}
 // this will tell whether the wallet can connection successfully to  daemon or not
 func Connect(endpoint string) (err error) {
 
+	var daemon_uri string
 	Daemon_Endpoint_Active = get_daemon_address()
 
 	logger.V(1).Info("Daemon endpoint ", "address", Daemon_Endpoint_Active)
 
-	rpc_client.WS, _, err = websocket.DefaultDialer.Dial("ws://"+Daemon_Endpoint_Active+"/ws", nil)
+	if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
+		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "https://")
+		daemon_uri = "wss://" + ld + "/ws"
+		logger.V(1).Info("will use endpoint", "endpoint", daemon_uri)
+
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(Daemon_Endpoint_Active, "wss") {
+		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "wss://")
+		daemon_uri = "wss://" + ld + "/ws"
+		logger.V(1).Info("will use endpoint", "endpoint", daemon_uri)
+
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else {
+		daemon_uri = "ws://" + Daemon_Endpoint_Active + "/ws"
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	}
 
 	// notify user of any state change
 	// if daemon connection breaks or comes live again
 	if err == nil {
 		if !Connected {
-			logger.V(1).Info("Connection to RPC server successful", "address", "ws://"+Daemon_Endpoint_Active+"/ws")
+			logger.V(1).Info("Connection to RPC server successful", "address", daemon_uri)
 			Connected = true
 		}
 	} else {
 
 		if Connected {
-			logger.V(1).Error(err, "Connection to RPC server Failed", "endpoint", "ws://"+Daemon_Endpoint_Active+"/ws")
+			logger.V(1).Error(err, "Connection to RPC server Failed", "endpoint", daemon_uri)
 		}
 		Connected = false
 		return

--- a/walletapi/daemon_connectivity.go
+++ b/walletapi/daemon_connectivity.go
@@ -62,14 +62,14 @@ func Connect(endpoint string) (err error) {
 
 	logger.V(1).Info("Daemon endpoint ", "address", Daemon_Endpoint_Active)
 
-	if strings.HasPrefix(Daemon_Endpoint_Active, "http") {
-		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "http://")
-		daemon_uri = "ws://" + ld + "/ws"
-
-		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
-	} else if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
+	if strings.HasPrefix(Daemon_Endpoint_Active, "https") {
 		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "https://")
 		daemon_uri = "wss://" + ld + "/ws"
+
+		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(Daemon_Endpoint_Active, "http") {
+		ld := strings.TrimPrefix(strings.ToLower(Daemon_Endpoint_Active), "http://")
+		daemon_uri = "ws://" + ld + "/ws"
 
 		rpc_client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
 	} else if strings.HasPrefix(Daemon_Endpoint_Active, "wss") {


### PR DESCRIPTION
## Description

This change will allow walletapi package calls to leverage the Connect() function to more appropriately connect to various defined endpoints (whether via the endpoint parameter or defined in --daemon-address params). 

Supported prefix endpoint uris:
* http://
* https://
* wss://
* ws://

If endpoint is not defined within the Connect() call, such as in [walletapi.Keep_Connectivity()](https://github.com/deroproject/derohe/blob/main/walletapi/daemon_connectivity_loop.go#L37), then the default will be utilized (127.0.0.1:xxxx) or if an argument was passed into globals then it will be used (whichever is returned from [get_daemon_address()](https://github.com/deroproject/derohe/blob/main/walletapi/daemon_communication.go#L122).

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [x] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).