### PR TITLE
Revert Comment Placing After PR #158

### DIFF
--- a/cmd/explorer/explorerlib/explorerlib.go
+++ b/cmd/explorer/explorerlib/explorerlib.go
@@ -36,7 +36,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	"unsafe"
+	"unsafe" // need to avoid this, but only used by byteviewer
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/channel"
@@ -50,8 +50,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gorilla/websocket"
 )
-
-// need to avoid this, but only used by byteviewer
 
 //import "encoding/json"
 //import "io/ioutil"


### PR DESCRIPTION
## Description

Places a comment back in the original place which was moved via golint in previous #158 pull request.

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [x] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).