### PR TITLE
Generate new randomness r for payload, distinct from amount

### DIFF
--- a/cryptography/crypto/userdata_test.go
+++ b/cryptography/crypto/userdata_test.go
@@ -1,0 +1,42 @@
+package crypto
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	var key [32]byte
+	expected := []byte("Hello World")
+	var payload []byte
+	payload = append(payload, expected...)
+
+	EncryptDecryptUserData(key, payload)
+	EncryptDecryptUserData(key, payload)
+
+	for i := range expected {
+		if expected[i] != payload[i] {
+			t.Fatal("error on encrypt/decrypt")
+		}
+	}
+}
+
+// TODO FIXME
+func TestSharedKey(t *testing.T) {
+	r := RandomScalar()
+	private_key := RandomScalarBNRed()
+	public_key := GPoint.ScalarMult(private_key)
+
+	encrypted_key := GenerateSharedSecret(r, public_key.G1())
+
+	big_key := new(big.Int).SetBytes(encrypted_key[:])
+	decrypted_r := new(big.Int).Mul(private_key.BigInt(), big_key)
+
+	r_bytes := r.Bytes()
+	decrypted_r_bytes := decrypted_r.Bytes()
+	for i := range r_bytes {
+		if r_bytes[i] != decrypted_r_bytes[i] {
+			t.Fatalf("error on shared key, index: %d", i)
+		}
+	}
+}

--- a/cryptography/crypto/userdata_test.go
+++ b/cryptography/crypto/userdata_test.go
@@ -1,8 +1,9 @@
 package crypto
 
 import (
-	"math/big"
 	"testing"
+
+	"github.com/deroproject/derohe/cryptography/bn256"
 )
 
 func TestEncryptDecrypt(t *testing.T) {
@@ -21,21 +22,20 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 }
 
-// TODO FIXME
 func TestSharedKey(t *testing.T) {
-	r := RandomScalar()
+	r := RandomScalarBNRed()
 	private_key := RandomScalarBNRed()
 	public_key := GPoint.ScalarMult(private_key)
 
-	encrypted_key := GenerateSharedSecret(r, public_key.G1())
+	// Create a curve point using PK
+	encrypted_key := new(bn256.G1).ScalarMult(public_key.G1(), r.BigInt())
 
-	big_key := new(big.Int).SetBytes(encrypted_key[:])
-	decrypted_r := new(big.Int).Mul(private_key.BigInt(), big_key)
+	// Decrypt it
+	decrypted_r := DeriveKeyFromPoint(encrypted_key, private_key.BigInt())
 
-	r_bytes := r.Bytes()
-	decrypted_r_bytes := decrypted_r.Bytes()
+	r_bytes := DeriveKeyFromR(r)
 	for i := range r_bytes {
-		if r_bytes[i] != decrypted_r_bytes[i] {
+		if r_bytes[i] != decrypted_r[i] {
 			t.Fatalf("error on shared key, index: %d", i)
 		}
 	}

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -16,15 +16,17 @@
 
 package proof
 
-import "fmt"
-import "math/big"
-import "strings"
-import "encoding/hex"
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
 
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/cryptography/bn256"
-import "github.com/deroproject/derohe/transaction"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+)
 
 //import "github.com/deroproject/derosuite/walletapi" // to decode encrypted payment ID
 
@@ -98,13 +100,20 @@ func Prove(proof string, input_tx string, ring_string [][]string, mainnet bool) 
 				receivers = append(receivers, astring.String())
 				amounts = append(amounts, amount)
 
-				//crypto.EncryptDecryptUserData(addr.PublicKey.G1(), tx.Payloads[t].RPCPayload)
-				crypto.EncryptDecryptUserData(crypto.Keccak256(shared_key[:], tx.Payloads[t].Statement.Publickeylist[k].EncodeCompressed()), tx.Payloads[t].RPCPayload)
-				// skip first byte as it is not guaranteed, even rest of the bytes are not
+				payload := tx.Payloads[t].RPCPayload
+				switch tx.Payloads[t].RPCType {
+				case transaction.ENCRYPTED_DEFAULT_PAYLOAD_CBOR:
+					crypto.EncryptDecryptUserData(crypto.Keccak256(shared_key[:], tx.Payloads[t].Statement.Publickeylist[k].EncodeCompressed()), payload)
+				case transaction.ENCRYPTED_DEFAULT_PAYLOAD_CBOR_V2:
+					// Skip first 66 bytes as they are encrypted keys for both parties
+					payload = payload[66:]
+					crypto.EncryptDecryptUserData(crypto.Keccak256(shared_key[:], tx.Payloads[t].Statement.Publickeylist[k].EncodeCompressed()), payload)
+				}
 
-				payload_raw = append(payload_raw, tx.Payloads[t].RPCPayload[1:])
+				// skip first byte as it is not guaranteed, even rest of the bytes are not
+				payload_raw = append(payload_raw, payload[1:])
 				var args rpc.Arguments
-				if err := args.UnmarshalBinary(tx.Payloads[t].RPCPayload[1:]); err == nil {
+				if err := args.UnmarshalBinary(payload[1:]); err == nil {
 					payload_decoded = append(payload_decoded, fmt.Sprintf("%s", args))
 				} else {
 					payload_decoded = append(payload_decoded, err.Error())

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -16,14 +16,16 @@
 
 package transaction
 
-import "fmt"
-import "bytes"
-import "math/big"
-import "encoding/binary"
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/big"
 
-import "github.com/deroproject/derohe/cryptography/crypto"
-import "github.com/deroproject/derohe/cryptography/bn256"
-import "github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/cryptography/bn256"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+)
 
 type TransactionType uint64
 
@@ -62,7 +64,14 @@ const PAYLOAD_LIMIT = 1 + 144 // entire payload header is mandatorily encrypted
 // 144 byte payload  ( to implement specific functionality such as delivery of keys etc), user dependent encryption
 const PAYLOAD0_LIMIT = 144 // 1 byte has been reserved for sender position in ring representation in a byte, uptp 256 ring
 
+// Payload V2 limit size
+// 33 bytes are for the two keys included in the payload for decrypt/encrypt process
+const PAYLOAD_V2_LIMIT = PAYLOAD0_LIMIT - (32 * 2)
+
 const ENCRYPTED_DEFAULT_PAYLOAD_CBOR = byte(0)
+
+// New payload format used
+const ENCRYPTED_DEFAULT_PAYLOAD_CBOR_V2 = byte(1)
 
 // the core transaction
 // in our design, tx cam be sent by 1 wallet, but SC part/gas can be signed by any other user, but this is not implemented

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -66,7 +66,7 @@ const PAYLOAD0_LIMIT = 144 // 1 byte has been reserved for sender position in ri
 
 // Payload V2 limit size
 // 33 bytes are for the two keys included in the payload for decrypt/encrypt process
-const PAYLOAD_V2_LIMIT = PAYLOAD0_LIMIT - (32 * 2)
+const PAYLOAD_V2_LIMIT = PAYLOAD0_LIMIT - (33 * 2)
 
 const ENCRYPTED_DEFAULT_PAYLOAD_CBOR = byte(0)
 

--- a/walletapi/transaction_build.go
+++ b/walletapi/transaction_build.go
@@ -149,8 +149,6 @@ rebuild_tx:
 		}
 
 		r_payload := crypto.RandomScalar()
-		r_payload_bytes := [32]byte{}
-		r_payload.FillBytes(r_payload_bytes[:])
 
 		for i := range publickeylist { // setup commitments
 			var x bn256.G1
@@ -186,8 +184,8 @@ rebuild_tx:
 
 				// Generate the keys for each party
 				// those are stored in the payload too
-				receiver_key := crypto.GenerateSharedSecret(r_payload, publickeylist[i])
 				sender_key := crypto.GenerateSharedSecret(r_payload, publickeylist[witness_index[0]])
+				receiver_key := crypto.GenerateSharedSecret(r_payload, publickeylist[i])
 
 				asset.RPCPayload = append(asset.RPCPayload, sender_key[:]...)
 				asset.RPCPayload = append(asset.RPCPayload, receiver_key[:]...)
@@ -199,7 +197,7 @@ rebuild_tx:
 
 				// make sure used data encryption is optional, just in case we would like to play together with ring members
 				// we intoduce an element to create dependency of input key, so receiver cannot prove otherwise
-				crypto.EncryptDecryptUserData(crypto.Keccak256(r_payload_bytes[:], publickeylist[i].EncodeCompressed()), payload)
+				crypto.EncryptDecryptUserData(crypto.Keccak256(r_payload.Bytes(), publickeylist[i].EncodeCompressed()), payload)
 
 				// Inject the encrypted payload now
 				asset.RPCPayload = append(asset.RPCPayload, payload...)


### PR DESCRIPTION
## Description

This PR is made to fix the privacy issue which allow to brute force and de-anonymize a TX.

What I'm doing is:
- Generate a new randomness named R
- Encrypt it using public keys from sender & receiver, and include it as overhead in the payload
- Generate a shared key from RG (r * G)
- Encrypt / Decrypt using the shared key
- Define a new RPC Type to handle it

- add test for encrypt/decrypt using new method
- support new format in daemon_communication.go

Fixes # (issue)
Fix the issue #178 

## Type of change

Please select the right one.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [x] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [x] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).