### PR TITLE
fix: assign network value to get info response

### DIFF
--- a/cmd/derod/rpc/rpc_dero_getinfo.go
+++ b/cmd/derod/rpc/rpc_dero_getinfo.go
@@ -87,6 +87,10 @@ func GetInfo(ctx context.Context) (result rpc.GetInfo_Result, err error) {
 
 	if globals.IsSimulator() {
 		result.Network = "Simulator"
+	} else if globals.IsMainnet() {
+		result.Network = "Mainnet"
+	} else {
+		result.Network = "Testnet"
 	}
 
 	in, out := p2p.Peer_Direction_Count()


### PR DESCRIPTION
## Description

Derod's rpc get info response doesn't include values for network other than "Simulator"

Fixes # (issue)

There is not an issue for it.

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [x] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [ ] Misc (documentation, comments, text...)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).