### PR TITLE
Fix/assign network to dvm address string

### DIFF
--- a/dvm/dvm_functions.go
+++ b/dvm/dvm_functions.go
@@ -16,17 +16,20 @@
 
 package dvm
 
-import "fmt"
-import "go/ast"
-import "strconv"
-import "strings"
-import "crypto/sha256"
-import "encoding/hex"
-import "golang.org/x/crypto/sha3"
-import "github.com/blang/semver/v4"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"go/ast"
+	"strconv"
+	"strings"
 
-import "github.com/deroproject/derohe/rpc"
-import "github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/blang/semver/v4"
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/globals"
+	"github.com/deroproject/derohe/rpc"
+	"golang.org/x/crypto/sha3"
+)
 
 // this files defines  external functions which can be called in DVM
 // for example to load and store data from the blockchain and other basic functions

--- a/dvm/dvm_functions.go
+++ b/dvm/dvm_functions.go
@@ -365,6 +365,7 @@ func dvm_address_string(dvm *DVM_Interpreter, expr *ast.CallExpr) (handled bool,
 		if err := p.DecodeCompressed([]byte(k)); err == nil {
 
 			addr := rpc.NewAddressFromKeys(p)
+			addr.Mainnet = globals.IsMainnet()
 			return true, addr.String()
 		}
 


### PR DESCRIPTION
## Description

Okay, to sum up - the `address_string` function (`func dvm_address_string`) uses `rpc.NewAddressFromKeys`, which does not evaluate `IsMainntet()` and assign `addr.Mainnet` because of cycle of imports error; and so the new address must be assigned its mainnet attribute after being created by the `rpc` package. 

> So, essentially, to fix this, we have to do this:

# The Fix:

`dvm/dvm_functions.go`
```go
import  "github.com/deroproject/derohe/globals"

func dvm_address_string(dvm *DVM_Interpreter, expr *ast.CallExpr) (handled bool, result string) {
    checkargscount(1, len(expr.Args)) // check number of arguments

    addr_eval := dvm.eval(expr.Args[0])
    switch k := addr_eval.(type) {
    case string:
        p := new(crypto.Point)
        if err := p.DecodeCompressed([]byte(k)); err == nil {

            addr := rpc.NewAddressFromKeys(p)
            addr.Mainnet = globals.IsMainnet() // ask global state: dero / deto
            return true, addr.String()
        }

        return true, "" // fallthrough not supported in type switch
    default:
        return true, ""
    }
}
```

Fixes # (issue)

https://github.com/secretnamebasis/derohe/issues/2#issuecomment-4905093278

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted ?

  - [ ] Wallet
  - [ ] Daemon
  - [ ] Miner
  - [ ] Explorer
  - [ ] Simulator
  - [x] Misc: DVM

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## License

Im am contributing & releasing the code under DERO Research License (which can be found [here](https://raw.githubusercontent.com/deroproject/derohe/main/license.txt)).