### PR TITLE
Fix historical miniblock address validation

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -592,7 +592,7 @@ func (chain *Blockchain) Add_Complete_Block(cbl *block.Complete_Block) (err erro
 		for _, mbl := range bl.MiniBlocks {
 			var miner_hash crypto.Hash
 			copy(miner_hash[:], mbl.KeyHash[:])
-			if mbl.Final == false && !chain.IsAddressHashValid(true, miner_hash) {
+			if mbl.Final == false && !chain.IsAddressHashValidAtTips(bl.Tips, miner_hash) {
 				err = fmt.Errorf("miner address not registered")
 				return err, false
 			}

--- a/blockchain/miner_block.go
+++ b/blockchain/miner_block.go
@@ -659,3 +659,61 @@ hard_way:
 
 	return true
 }
+
+// IsAddressHashValidAtTips validates miner addresses against the candidate block's maturity window.
+func (chain *Blockchain) IsAddressHashValidAtTips(tips []crypto.Hash, hashes ...crypto.Hash) (found bool) {
+	if len(hashes) == 0 {
+		return true
+	}
+
+	chainTopo := chain.Load_TOPO_HEIGHT()
+	candidateTopo := chainTopo
+	if len(tips) > 0 {
+		tipTopo := chain.Load_Block_Topological_order(tips[0])
+		if tipTopo >= 0 {
+			candidateTopo = tipTopo + 1
+		}
+	}
+
+	maxTopo := addressValidationLookupTopo(chainTopo, candidateTopo)
+
+	toporecord, err := chain.Store.Topo_store.Read(maxTopo)
+	if err != nil {
+		return false
+	}
+
+	ss, err := chain.Store.Balance_store.LoadSnapshot(toporecord.State_Version)
+	if err != nil {
+		return false
+	}
+
+	balanceTree, err := ss.GetTree(config.BALANCE_TREE)
+	if err != nil {
+		return false
+	}
+
+	for _, hash := range hashes {
+		bits, _, _, err := balanceTree.GetKeyValueFromHash(hash[:16])
+		if err != nil || bits >= 120 {
+			return false
+		}
+	}
+	return true
+}
+
+func addressValidationLookupTopo(chainTopo, candidateTopo int64) int64 {
+	if candidateTopo < 0 {
+		candidateTopo = 0
+	}
+	lookupTopo := candidateTopo
+	if lookupTopo > 25 {
+		lookupTopo -= 25
+	}
+	if lookupTopo > chainTopo {
+		lookupTopo = chainTopo
+	}
+	if lookupTopo < 0 {
+		return 0
+	}
+	return lookupTopo
+}

--- a/blockchain/miner_block_test.go
+++ b/blockchain/miner_block_test.go
@@ -1,0 +1,26 @@
+package blockchain
+
+import "testing"
+
+func TestAddressValidationLookupTopoUsesCandidateBlockWindow(t *testing.T) {
+	tests := []struct {
+		name          string
+		chainTopo     int64
+		candidateTopo int64
+		want          int64
+	}{
+		{name: "candidate 29 sees registration at topo 4", chainTopo: 28, candidateTopo: 29, want: 4},
+		{name: "candidate 30 sees registration at topo 5", chainTopo: 29, candidateTopo: 30, want: 5},
+		{name: "early chain clamps to current state", chainTopo: 3, candidateTopo: 4, want: 3},
+		{name: "candidate topo below maturity clamps to current state", chainTopo: 20, candidateTopo: 21, want: 20},
+		{name: "negative candidate clamps to zero", chainTopo: 0, candidateTopo: -1, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addressValidationLookupTopo(tt.chainTopo, tt.candidateTopo); got != tt.want {
+				t.Fatalf("lookup topo mismatch: got %d want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`Add_Complete_Block` validates miniblock miner registration before the candidate block is added. The existing check derives the 25-topo maturity snapshot from the node's local tip, so a syncing node at topo 28 validating candidate topo 29 checks topo 3 instead of topo 4. A miner registration that is valid for the candidate can therefore be rejected as `miner address not registered`, preventing synchronization.

This change selects the validation snapshot from the candidate block's tips, while retaining the existing local-tip fallback and 16-byte address-prefix lookup. It also adds boundary coverage for the maturity window and early-chain clamping.

Related issue: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This will require a HardFork to be enabled

## Which part is impacted?

- [ ] Wallet
- [x] Daemon
- [x] Miner
- [ ] Explorer
- [ ] Simulator
- [ ] Misc (documentation, comments, text...)

## Test plan

- [x] `go test ./...`
- [x] Added unit cases for candidate topo 29/30, early-chain behavior, and negative bounds

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented the new exported validation method
- [x] My changes generate no new warnings

## License

I am contributing and releasing the code under the DERO Research License.

Made with [Cursor](https://cursor.com)